### PR TITLE
Get qemu-user to pass correct argv[0]

### DIFF
--- a/qemu-user.nix
+++ b/qemu-user.nix
@@ -22,12 +22,13 @@ stdenv.mkDerivation rec {
   ];
   NIX_LDFLAGS = [ "-lglib-2.0" "-lssp" ];
   postInstall = ''
+    NIX_LDFLAGS= cc ${./qemu-wrap.c} -D QEMU_ARM_BIN="\"$out/bin/qemu-arm"\" -o $out/bin/qemu-wrap
     cat <<EOF > $out/bin/register
     #!/bin/sh
     modprobe binfmt_misc
     mount -t binfmt_misc binfmt_misc  /proc/sys/fs/binfmt_misc
     ${
-      if user_arch == "arm" then ''echo   ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\x00\xff\xfe\xff\xff\xff:$out/bin/qemu-arm:' > /proc/sys/fs/binfmt_misc/register''
+      if user_arch == "arm" then ''echo   ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\x00\xff\xfe\xff\xff\xff:$out/bin/qemu-wrap:P' > /proc/sys/fs/binfmt_misc/register''
       else if user_arch == "aarch64" then ''echo   ':aarch64:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\x00\xff\xfe\xff\xff\xff:$out/bin/qemu-aarch64:' > /proc/sys/fs/binfmt_misc/register''
       else "echo unknown arch"
     }

--- a/qemu-user.nix
+++ b/qemu-user.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   ];
   NIX_LDFLAGS = [ "-lglib-2.0" "-lssp" ];
   postInstall = ''
-    NIX_LDFLAGS= cc ${./qemu-wrap.c} -D QEMU_ARM_BIN="\"$out/bin/qemu-arm"\" -o $out/bin/qemu-wrap
+    NIX_LDFLAGS= cc -static ${./qemu-wrap.c} -D QEMU_ARM_BIN="\"$out/bin/qemu-arm"\" -o $out/bin/qemu-wrap
     cat <<EOF > $out/bin/register
     #!/bin/sh
     modprobe binfmt_misc

--- a/qemu-wrap.c
+++ b/qemu-wrap.c
@@ -1,0 +1,52 @@
+#include <alloca.h>
+#include <malloc.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#if !defined(QEMU_ARM_BIN)
+  #define QEMU_ARM_BIN "qemu-arm"
+#endif
+
+// This program takes arguments according to the behavior of binfmt_misc with
+// the preserve-argv[0] flag set.
+//
+// The first value in argv is the name of this executable, uninteresting.
+// The second value is the full path of the executable to run with the
+// alternate interpreter.
+// The third value is the name that executable was called with.
+//
+// This program passes the third value in to qemu-arm after the -0 flag.
+int main(int argc, char const* argv[]) {
+  // Abort if we don't have sufficient arguments
+  if(argc < 3){
+    fprintf( stderr, "qemu-arm wrapper called with too few arguments.\nEnsure that the 'P' flag is set in binfmt_misc.\n");
+    return -1;
+  }
+
+  // Allocate the new argc array to pass to qemu-arm
+  const int new_argc = argc + 1;
+  char** const new_argv = alloca((new_argc + 1) * sizeof(void *));
+
+  // Fill this new array
+  new_argv[0] = strdup(QEMU_ARM_BIN);
+  new_argv[1] = strdup("-0");
+  new_argv[2] = strdup(argv[2]);
+  new_argv[3] = strdup(argv[1]);
+  for(int i = 4; i < new_argc; ++i){
+    new_argv[i] = strdup(argv[i-1]);
+  }
+  new_argv[new_argc] = NULL;
+
+  // Run qemu with the new arguments
+  execvp(new_argv[0], new_argv);
+  const int ret = errno;
+
+  // Clean up, haha C
+  for(int i = 0; i < new_argc; ++i){
+    free(new_argv[i]);
+  }
+
+  return ret;
+};


### PR DESCRIPTION
This is necessary to build runit with tests. It allows more coreutils
tests to pass too.